### PR TITLE
added nvarchar data type to definitions, added additional model/file generation options, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,9 @@ const dbOptions = {
 const options = {
   type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
   camelCase: false, // Model name camel case. Default is false.
-  noModelSuffix: false, // Removes the "Model" or "_model" suffix added to model names.
+  noModelSuffix: false, // Removes the "Model" or "_model" suffix added to model names. Default is false.
   fileNameCamelCase: false, // Model file name camel case. Default is false.
-  fileNameMatchesModel: false, // Write the file with the same name as the model.
+  fileNameMatchesModel: false, // Write the file with the same name as the model. Default is false.
   dir: 'models', // What directory to place the models. Default is `models`.
   typesDir: 'models', // What directory to place the models' definitions (for typescript), default is the same with dir.
   emptyDir: false, // Remove all files in `dir` and `typesDir` directories before generate models.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,9 @@ const dbOptions = {
 const options = {
   type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
   camelCase: false, // Model name camel case. Default is false.
-  fileNameCamelCase: true, // Model file name camel case. Default is false.
+  noModelSuffix: false, // Removes the "Model" or "_model" suffix added to model names.
+  fileNameCamelCase: false, // Model file name camel case. Default is false.
+  fileNameMatchesModel: false, // Write the file with the same name as the model.
   dir: 'models', // What directory to place the models. Default is `models`.
   typesDir: 'models', // What directory to place the models' definitions (for typescript), default is the same with dir.
   emptyDir: false, // Remove all files in `dir` and `typesDir` directories before generate models.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ const dbOptions = {
 // Automate options
 const options = {
   type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
+  sequelizeNamespace: '', ////Specify a custom sequelize namespace that will be used during model generation instead of requiring sequelize, e.g. 'app.sequelize'. Default is empty string.
+  templatePath: '', //Specify a path to a custom template for model generation. Default uses sequelize-automate template depending on 'type'.
   camelCase: false, // Model name camel case. Default is false.
   noModelSuffix: false, // Removes the "Model" or "_model" suffix added to model names. Default is false.
   fileNameCamelCase: false, // Model file name camel case. Default is false.

--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -8,20 +8,20 @@ const processMidway = require('./midway');
  * @param {object} definition definition
  * @param {object} options
  */
-function generate(definition, options) {
+function generate(definition, templatePath, options) {
   const { type, tsNoCheck } = options;
   switch (type) {
     case 'js':
-      return processJS(definition, { isEgg: false });
+      return processJS(definition, templatePath, { isEgg: false });
     case 'ts':
-      return processTS(definition, { tsNoCheck });
+      return processTS(definition, templatePath, { tsNoCheck });
     case 'egg':
-      return processJS(definition, { isEgg: true });
+      return processJS(definition, templatePath, { isEgg: true });
     case 'midway':
-      return processMidway(definition, { tsNoCheck });
+      return processMidway(definition, templatePath, { tsNoCheck });
     case '@ali/midway':
       // special for @ali/midway
-      return processMidway(definition, { tsNoCheck, isAliMidway: true });
+      return processMidway(definition, templatePath, { tsNoCheck, isAliMidway: true });
     default:
       break;
   }

--- a/src/generate/javascript.js
+++ b/src/generate/javascript.js
@@ -17,10 +17,10 @@ const {
  * @param {object} definition
  * @param {object} options
  */
-function generateCode(definition, options) {
+function generateCode(definition, templatePath, options) {
   const file = options.isEgg ? './template/egg/user.text' : './template/javascript/user.text';
   const source = fs
-    .readFileSync(join(__dirname, file))
+    .readFileSync(templatePath ? templatePath : join(__dirname, file))
     .toString();
 
   const ast = parse(source, {
@@ -71,12 +71,12 @@ function generateCode(definition, options) {
   return code;
 }
 
-function process(definitions, options) {
+function process(definitions, templatePath, options) {
   const modelCodes = definitions.map((definition) => {
     const { modelFileName } = definition;
     const fileType = 'model';
     const file = `${modelFileName}.js`;
-    const code = generateCode(definition, options);
+    const code = generateCode(definition, templatePath, options);
     return {
       file,
       code,

--- a/src/generate/midway.js
+++ b/src/generate/midway.js
@@ -19,9 +19,9 @@ const {
  * @param {object} definition
  * @param {object} options
  */
-function generateCode(definition, options) {
+function generateCode(definition, templatePath, options) {
   const source = fs
-    .readFileSync(join(__dirname, './template/midway/user.text'))
+    .readFileSync(templatePath ? templatePath : join(__dirname, file))
     .toString();
 
   const ast = parse(source, {
@@ -160,12 +160,12 @@ function generateDB(options) {
   return code;
 }
 
-function process(definitions, options) {
+function process(definitions, templatePath, options) {
   const modelCodes = definitions.map((definition) => {
     const { modelFileName } = definition;
     const fileType = 'model';
     const file = `${modelFileName}.ts`;
-    const code = generateCode(definition, options);
+    const code = generateCode(definition, templatePath, options);
     return {
       file,
       code,

--- a/src/generate/typescript.js
+++ b/src/generate/typescript.js
@@ -19,9 +19,9 @@ const {
  * @param {object} definition
  * @param {object} options
  */
-function generateCode(definition, options) {
+function generateCode(definition, templatePath, options) {
   const source = fs
-    .readFileSync(join(__dirname, './template/typescript/user.text'))
+    .readFileSync(templatePath ? templatePath : join(__dirname, file))
     .toString();
 
   const ast = parse(source, {
@@ -141,12 +141,12 @@ function generateDefinition(definition) {
   return code;
 }
 
-function process(definitions, options) {
+function process(definitions, templatePath, options) {
   const modelCodes = definitions.map((definition) => {
     const { modelFileName } = definition;
     const fileType = 'model';
     const file = `${modelFileName}.ts`;
-    const code = generateCode(definition, options);
+    const code = generateCode(definition, templatePath, options);
     return {
       file,
       code,

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,9 @@ class Automate {
     const defaultOptions = {
       type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
       camelCase: false, // Model name camel case. Default is false.
+      noModelSuffix: true,
       fileNameCamelCase: false, // Model file name camel case. Default is false.
+      fileNameMatchesModel: true,
       dir: 'models', // What directory to place the models. Default is `models`.
       typesDir: null, // What directory to place the models' definitions (for typescript), default is the same with dir.
       emptyDir: false, // Remove all files in `dir` and `typesDir` directories before generate models.
@@ -32,7 +34,9 @@ class Automate {
     const supportTypes = ['js', 'ts', 'egg', 'midway', '@ali/midway'];
     assert(supportTypes.includes(this.options.type), 'type not support');
     assert(_.isBoolean(this.options.camelCase), 'Invalid params camelCase');
+    assert(_.isBoolean(this.options.noModelSuffix), 'Invalid params noModelSuffix');
     assert(_.isBoolean(this.options.fileNameCamelCase), 'Invalid params fileNameCamelCase');
+    assert(_.isBoolean(this.options.fileNameMatchesModel), 'Invalid params fileNameMatchesModel');
     assert(_.isString(this.options.dir), 'Invalid params dir');
     assert(_.isString(this.options.typesDir), 'Invalid params typesDir');
     assert(_.isBoolean(this.options.emptyDir), 'Invalid params cleanDir');
@@ -107,7 +111,9 @@ class Automate {
       tables,
       skipTables,
       camelCase,
+      noModelSuffix,
       fileNameCamelCase,
+      fileNameMatchesModel
     } = this.options;
     const allTables = await this.getTables({
       tables,
@@ -115,7 +121,9 @@ class Automate {
     });
     const definitions = getModelDefinitions(allTables, {
       camelCase,
+      noModelSuffix,
       fileNameCamelCase,
+      fileNameMatchesModel,
       dialect: this.dbOptions.dialect,
     });
     debug('get model definitions');
@@ -129,7 +137,9 @@ class Automate {
       tables,
       skipTables,
       camelCase,
+      noModelSuffix,
       fileNameCamelCase,
+      fileNameMatchesModel,
       tsNoCheck,
       dir,
       typesDir,
@@ -139,7 +149,9 @@ class Automate {
       tables,
       skipTables,
       camelCase,
+      noModelSuffix,
       fileNameCamelCase,
+      fileNameMatchesModel
     });
 
     const codes = generate(definitions, {

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ class Automate {
     debug('sequelize-automate constructor');
     const defaultOptions = {
       type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
+      sequelizeNamespace: '', //Specify a custom sequelize namespace that will be used during model generation instead of requiring sequelize, e.g. 'app.sequelize'. Default is empty string.
+      templatePath: '', //Specify a path to a custom template for model generation. Default uses sequelize-automate template depending on 'type'.
       camelCase: false, // Model name camel case. Default is false.
       noModelSuffix: false, // Removes the "Model" or "_model" suffix added to model names. Default is false.
       fileNameCamelCase: false, // Model file name camel case. Default is false.
@@ -34,6 +36,8 @@ class Automate {
     const supportTypes = ['js', 'ts', 'egg', 'midway', '@ali/midway'];
     assert(supportTypes.includes(this.options.type), 'type not support');
     assert(_.isBoolean(this.options.camelCase), 'Invalid params camelCase');
+    assert(_.isString(this.options.sequelizeNamespace), 'Invalid params sequelizeNamespace');
+    assert(_.isString(this.options.templatePath), 'Invalid params templatePath');
     assert(_.isBoolean(this.options.noModelSuffix), 'Invalid params noModelSuffix');
     assert(_.isBoolean(this.options.fileNameCamelCase), 'Invalid params fileNameCamelCase');
     assert(_.isBoolean(this.options.fileNameMatchesModel), 'Invalid params fileNameMatchesModel');
@@ -108,6 +112,7 @@ class Automate {
 
   async getDefinitions() {
     const {
+      sequelizeNamespace,
       tables,
       skipTables,
       camelCase,
@@ -120,6 +125,7 @@ class Automate {
       skipTables,
     });
     const definitions = getModelDefinitions(allTables, {
+      sequelizeNamespace,
       camelCase,
       noModelSuffix,
       fileNameCamelCase,
@@ -134,6 +140,8 @@ class Automate {
   async run() {
     const {
       type,
+      sequelizeNamespace,
+      templatePath,
       tables,
       skipTables,
       camelCase,
@@ -146,6 +154,7 @@ class Automate {
       emptyDir,
     } = this.options;
     const definitions = await this.getDefinitions({
+      sequelizeNamespace,
       tables,
       skipTables,
       camelCase,
@@ -154,7 +163,7 @@ class Automate {
       fileNameMatchesModel
     });
 
-    const codes = generate(definitions, {
+    const codes = generate(definitions, templatePath, {
       type,
       tsNoCheck,
     });

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,9 @@ class Automate {
     const defaultOptions = {
       type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
       camelCase: false, // Model name camel case. Default is false.
-      noModelSuffix: false,
+      noModelSuffix: false, // Removes the "Model" suffix added to a model if camelCase is set to true.
       fileNameCamelCase: false, // Model file name camel case. Default is false.
-      fileNameMatchesModel: false,
+      fileNameMatchesModel: false, // Write the file with the same name as the model.
       dir: 'models', // What directory to place the models. Default is `models`.
       typesDir: null, // What directory to place the models' definitions (for typescript), default is the same with dir.
       emptyDir: false, // Remove all files in `dir` and `typesDir` directories before generate models.

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,9 @@ class Automate {
     const defaultOptions = {
       type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
       camelCase: false, // Model name camel case. Default is false.
-      noModelSuffix: false, // Removes the "Model" or "_model" suffix added to model names.
+      noModelSuffix: false, // Removes the "Model" or "_model" suffix added to model names. Default is false.
       fileNameCamelCase: false, // Model file name camel case. Default is false.
-      fileNameMatchesModel: false, // Write the file with the same name as the model.
+      fileNameMatchesModel: false, // Write the file with the same name as the model. Default is false.
       dir: 'models', // What directory to place the models. Default is `models`.
       typesDir: null, // What directory to place the models' definitions (for typescript), default is the same with dir.
       emptyDir: false, // Remove all files in `dir` and `typesDir` directories before generate models.

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ class Automate {
     const defaultOptions = {
       type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
       camelCase: false, // Model name camel case. Default is false.
-      noModelSuffix: false, // Removes the "Model" suffix added to a model if camelCase is set to true.
+      noModelSuffix: false, // Removes the "Model" or "_model" suffix added to model names.
       fileNameCamelCase: false, // Model file name camel case. Default is false.
       fileNameMatchesModel: false, // Write the file with the same name as the model.
       dir: 'models', // What directory to place the models. Default is `models`.

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,9 @@ class Automate {
     const defaultOptions = {
       type: 'js', // Which code style want to generate, supported: js/ts/egg/midway. Default is `js`.
       camelCase: false, // Model name camel case. Default is false.
-      noModelSuffix: true,
+      noModelSuffix: false,
       fileNameCamelCase: false, // Model file name camel case. Default is false.
-      fileNameMatchesModel: true,
+      fileNameMatchesModel: false,
       dir: 'models', // What directory to place the models. Default is `models`.
       typesDir: null, // What directory to place the models' definitions (for typescript), default is the same with dir.
       emptyDir: false, // Remove all files in `dir` and `typesDir` directories before generate models.

--- a/src/util/definition.js
+++ b/src/util/definition.js
@@ -267,7 +267,7 @@ function processTable({
  * @return {object} [{ modelName, modelFileName, tableName, attributes, indexes }]
  */
 function getModelDefinitions(tables, options) {
-  const { sequelizeNamespace, camelCase, noModelSuffix, fileNameCamelCase, fileNameMatchModel, dialect, } = options || {};
+  const { sequelizeNamespace, camelCase, noModelSuffix, fileNameCamelCase, fileNameMatchesModel, dialect, } = options || {};
   const definitions = _.map(tables, (table, tableName) => {
     const { attributes, indexes } = processTable({
       sequelizeNamespace: sequelizeNamespace,
@@ -279,7 +279,7 @@ function getModelDefinitions(tables, options) {
     });
 
     const modelName = getModelName(tableName, camelCase, noModelSuffix);
-    const modelFileName = fileNameMatchModel ? modelName : getFieldName(tableName, fileNameCamelCase);
+    const modelFileName = fileNameMatchesModel ? modelName : getFieldName(tableName, fileNameCamelCase);
     return {
       modelName,
       modelFileName,

--- a/src/util/definition.js
+++ b/src/util/definition.js
@@ -131,7 +131,7 @@ function getDataType(field) {
     return type;
   }
 
-  if (attr.match(/^varchar/)) {
+  if (attr.match(/^(varchar|nvarchar)/)) {
     return `DataTypes.STRING${typeLength}`;
   }
 

--- a/src/util/definition.js
+++ b/src/util/definition.js
@@ -6,8 +6,13 @@ function getFieldName(fieldName, camelCase) {
   return camelCase ? _.camelCase(fieldName) : fieldName;
 }
 
-function getModelName(tableName, camelCase) {
-  const modelString = camelCase ? 'Model' : '_model';
+function getModelName(tableName, camelCase, noModelSuffix) {
+  const modelString = camelCase
+    ? noModelSuffix
+      ? ''
+      : 'Model'
+    : '_model';
+
   return `${getFieldName(tableName, camelCase)}${modelString}`;
 }
 
@@ -199,6 +204,7 @@ function processTable({
   structures,
   allIndexes,
   foreignKeys,
+  noModelSuffix,
   options,
 }) {
   const { camelCase, dialect } = options;
@@ -242,7 +248,7 @@ function processTable({
     const filed = getFieldName(columnName, camelCase);
     attributes[filed].references = {
       key: referencedColumnName,
-      model: getModelName(referencedTableName, camelCase),
+      model: getModelName(referencedTableName, camelCase, noModelSuffix),
     };
   });
 
@@ -256,17 +262,18 @@ function processTable({
  * @return {object} [{ modelName, modelFileName, tableName, attributes, indexes }]
  */
 function getModelDefinitions(tables, options) {
-  const { camelCase, fileNameCamelCase, dialect } = options || {};
+  const { camelCase, noModelSuffix, fileNameCamelCase, fileNameMatchModel, dialect, } = options || {};
   const definitions = _.map(tables, (table, tableName) => {
     const { attributes, indexes } = processTable({
       structures: table.structures,
       allIndexes: table.indexes,
       foreignKeys: table.foreignKeys,
+      noModelSuffix: noModelSuffix,
       options: { camelCase, dialect },
     });
 
-    const modelName = getModelName(tableName, camelCase);
-    const modelFileName = getFieldName(tableName, fileNameCamelCase);
+    const modelName = getModelName(tableName, camelCase, noModelSuffix);
+    const modelFileName = fileNameMatchModel ? modelName : getFieldName(tableName, fileNameCamelCase);
     return {
       modelName,
       modelFileName,

--- a/src/util/definition.js
+++ b/src/util/definition.js
@@ -7,11 +7,11 @@ function getFieldName(fieldName, camelCase) {
 }
 
 function getModelName(tableName, camelCase, noModelSuffix) {
-  const modelString = camelCase
-    ? noModelSuffix
-      ? ''
-      : 'Model'
-    : '_model';
+  const modelString = noModelSuffix
+    ? ''
+    : camelCase
+      ? 'Model'
+      : '_model';
 
   return `${getFieldName(tableName, camelCase)}${modelString}`;
 }

--- a/src/util/write.js
+++ b/src/util/write.js
@@ -4,7 +4,14 @@ const debug = require('debug')('sequelize-automate');
 
 
 async function writeFile(code, dir, fileName) {
-  const dirPath = dir.charAt(0) === '/' ? dir : path.join(process.cwd(), dir);
+  dir = dir.replace(/\\/g, '/') //convert to posix path
+
+  const dirPath = dir.charAt(0) === '/'
+    ? dir
+    : dir.split('/')[0].indexOf(':') > -1 //is absolute windows path
+      ? dir
+      : path.join(process.cwd(), dir);
+
   await fs.ensureDir(dirPath);
   const filePath = path.join(dirPath, fileName);
   debug('write file', filePath);


### PR DESCRIPTION
**changes:**

- added **nvarchar** data type to definitions for microsoft sql server and other dialects.
- added additional **options** for model generation.
- updated README
- convert  dir/typeDir to posix path in writeFile()
- allow dir/typeDir as absolute windows path in writeFile()

**options**:

- **noModelSuffix**: removes the "Model" or "_model" suffix added to model names. default is false.
- **fileNameMatchesModel**: write the file with the same name as the model. default is false.
- **sequelizeNamespace**: specify a custom sequelize namespace that will be used during model generation instead of requiring sequelize, e.g. 'app.sequelize'. default is empty string.
- **templatePath**:  specify a path to a custom template for model generation. default uses sequelize-automate template depending on 'type'.