### PR TITLE
fixed invalid password handling, improved logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Options:
   --host, -h      IP/Hostname for the database.  [string] [default: "localhost"]
   --database, -d  Database name.                      [string] [default: "test"]
   --user, -u      Username for database.              [string] [default: "root"]
-  --password, -p  Password for database.              [string] [default: "root"]
+  --password, -p  Password for database.              [string] 
   --port, -P      Port number for database. e.g. MySQL/MariaDB: 3306, Postgres:
                   5432, MSSQL: 1433                                     [number]
   --dialect, -e   The dialect/engine that you're using: mysql, sqlite, postgres,

--- a/bin/sequelize-automate
+++ b/bin/sequelize-automate
@@ -48,7 +48,6 @@ const { argv } = yargs
     alias: 'p',
     describe: 'Password for database.',
     type: 'string',
-    default: 'root',
   })
   .option('port', {
     alias: 'P',
@@ -113,7 +112,11 @@ const options = _.assign({}, {
 }, configFile ? configFile.options : {});
 
 const dbOptionsCopy = _.cloneDeep(dbOptions);
-dbOptionsCopy.password = '****';
+if (dbOptionsCopy.password !== undefined)
+  dbOptionsCopy.password = '*'.repeat(dbOptionsCopy.password.length);
+//Added for better readability on command output
+else dbOptionsCopy.password = null;
+
 console.log('Database options:', JSON.stringify(dbOptionsCopy));
 console.log('Automate options:', JSON.stringify(options));
 


### PR DESCRIPTION
Fixed #13 
Fixed invalid passing of missing password to sequelize by removing default password in `bin\sequelize-automate`.
Changed the README.md to reflect these changes.
The '*' redacting the password output to the console now have the correct length and are not displayed when a password is not specified