### PR TITLE
Add ability to match tables that only matches a given RegExp

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Options:
   --config, -c    Sequelize automate config file, see README.md         [string]
   --emptyDir, -r  Remove all files in `dir` and `typesDir` directories before
                   generate models.                    [boolean] [default: false]
+  --match, -m     Match tables using given RegExp.    [string] [default: null]
 ```
 
 #### Example
@@ -268,6 +269,7 @@ const options = {
   tables: null, // Use these tables, Example: ['user'], default is null.
   skipTables: null, // Skip these tables. Example: ['user'], default is null.
   tsNoCheck: false, // Whether add @ts-nocheck to model files, default is false.
+  match: null // RegExp to match table name
 }
 
 const automate = new Automate(dbOptions, options);

--- a/bin/sequelize-automate
+++ b/bin/sequelize-automate
@@ -83,6 +83,11 @@ const { argv } = yargs
     type: 'boolean',
     default: false,
     describe: 'Remove all files in `dir` and `typesDir` directories before generate models.',
+  }).option('match', {
+    alias: 'm',
+    type: 'string',
+    default: null,
+    describe: 'Match tables using given RegExp.',
   });
 
 let configFile = null;

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ class Automate {
       tables: null, // Use these tables, Example: ['user'], default is null.
       skipTables: null, // Skip these tables. Example: ['user'], default is null.
       tsNoCheck: false, // Whether add `@ts-nocheck` to model files, default is false.
+      matchTable: null
     };
 
     // https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor
@@ -46,7 +47,16 @@ class Automate {
 
   async getTableNames({ tables, skipTables }) {
     // TODO: check all dialects https://github.com/sequelize/sequelize/issues/11451
-    const tableNames = await this.queryInterface.showAllTables();
+    const allTableNames = await this.queryInterface.showAllTables();
+
+    let tableNames = allTableNames;
+    if (this.options.matchTable !== null) {
+      const regex = RegExp(this.options.matchTable);
+      tableNames = allTableNames.filter((tableName) => (
+        _.isPlainObject(tableName) ? regex.test(tableName.tableName) : regex.test(tableName)
+      ));
+    }
+
     const allTables = _.map(tableNames, (tableName) => (
       _.isPlainObject(tableName) ? tableName.tableName : tableName
     ));

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ class Automate {
       tables: null, // Use these tables, Example: ['user'], default is null.
       skipTables: null, // Skip these tables. Example: ['user'], default is null.
       tsNoCheck: false, // Whether add `@ts-nocheck` to model files, default is false.
-      matchTable: null
+      match: null // Regex to match table name
     };
 
     // https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor
@@ -50,8 +50,8 @@ class Automate {
     const allTableNames = await this.queryInterface.showAllTables();
 
     let tableNames = allTableNames;
-    if (this.options.matchTable !== null) {
-      const regex = RegExp(this.options.matchTable);
+    if (this.options.match !== null) {
+      const regex = RegExp(this.options.match);
       tableNames = allTableNames.filter((tableName) => (
         _.isPlainObject(tableName) ? regex.test(tableName.tableName) : regex.test(tableName)
       ));

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -69,5 +69,19 @@ describe("test/src/index.test.js", () => {
       const expected = getDefinitions("user");
       expect(definitions).toEqual(expected);
     });
+
+    test("filter table: ", async () => {
+      const automate = new Automate(
+        config.dbOptions,
+        _.assign({}, config.options, {
+          matchTable: 'post'
+        })
+      );
+
+      const definitions = await automate.getDefinitions();
+      expect(definitions[0].modelName).toEqual('user_post_model');
+      expect(definitions[0].tableName).toEqual('user_post');
+      expect(definitions[0].modelFileName).toEqual('user_post');
+    });
   });
 });

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -74,7 +74,7 @@ describe("test/src/index.test.js", () => {
       const automate = new Automate(
         config.dbOptions,
         _.assign({}, config.options, {
-          matchTable: 'post'
+          match: 'post'
         })
       );
 


### PR DESCRIPTION
**Backstory:**
I needed to create models for tables with prefix "code".

**Example:**
I have 3 tables named users, codeRace, codeColor. I need to create models for codeRace and codeColor not for users.

**Implementation:**
I have added an additional parameter `--match` that would take a RegExp and filter tables according to that given RegExp.